### PR TITLE
composer.json fix: now it downloads the dependencies correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
 
-        "elogank/lol-replay-downloader": "1.1.*@dev",
+        "elogank/lol-replay-downloader": "1.2.*@dev",
 
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
The dependency lol-replay-downloader returned an error. Now it is fixed.